### PR TITLE
Adiciona OpenStack como opção de provider

### DIFF
--- a/env/.env.openstack.sample
+++ b/env/.env.openstack.sample
@@ -1,5 +1,8 @@
 # You can get this informations on rc-file downloaded from dashboard
 export OS_AUTH_URL=
 export OS_USERNAME=
-export OS_PASSWORD= 
+export OS_PASSWORD=
 export OS_PROJECT_ID=
+export OS_PROJECT_DOMAIN_ID=
+export OS_INTERFACE=
+export OS_USER_DOMAIN_NAME=

--- a/env/.env.openstack.sample
+++ b/env/.env.openstack.sample
@@ -1,0 +1,5 @@
+# You can get this informations on rc-file downloaded from dashboard
+export OS_AUTH_URL=
+export OS_USERNAME=
+export OS_PASSWORD= 
+export OS_PROJECT_ID=

--- a/parse_tf_output.py
+++ b/parse_tf_output.py
@@ -3,7 +3,7 @@ import sys
 
 provider = sys.argv[1]
 
-if provider == 'aws':
+if provider == 'aws' or 'openstack':
     user = 'ubuntu'
 elif provider == 'hetzner':
     user = 'root'

--- a/terraform/openstack/.terraform.lock.hcl
+++ b/terraform/openstack/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/terraform-provider-openstack/openstack" {
+  version     = "1.53.0"
+  constraints = "~> 1.53.0"
+  hashes = [
+    "h1:ZSJPqrlaHQ3sj7wyJuPSG+NblFZbAA6Y0d3GjSJf3o8=",
+    "zh:09da7ca98ffd3de7b9ce36c4c13446212a6e763ba1162be71b50f95d453cb68e",
+    "zh:14041bcbb87312411d88612056ed185650bfd01284b8ea0761ce8105a331708e",
+    "zh:35bf4c788fdbc17c8e40ebc7b33c7de4b45a2fa2efaa657b10f0e3bd37c9627f",
+    "zh:46ede8ef4cfa12d654c538afc1e1ec34a1f3e8eb4e986ee23dceae398b7176a6",
+    "zh:59675734990dab1e8d87997853ea75e8104bba730b3f5a7146ac735540c9d6bf",
+    "zh:6de52428849806498670e827b54810be7510a2a79449602c1aede4235a0ec036",
+    "zh:78b2a20601272afceffac8f8ca78a6b647b84196c0dd8dc710fae297f6be15a4",
+    "zh:7c41ed3a4fac09677e676ecf9f9edd1e38eef449e656cb01a848d2c799c6de8f",
+    "zh:852800228f4118a4aa6cfaa4468b851247cbed6f037fd204f08de69eb1edc149",
+    "zh:86d618e7f9a07d978b8bc4b190be350a00de64ec535f9c8f5dfe133542a55483",
+    "zh:963a9e72b66d8bcf43de9b14a674ae3ca3719ce2f829217f7a65b66fc3773397",
+    "zh:a8e72ab67795071bda61f99a6de3d2d40122fb51971768fd75e1324abe874ced",
+    "zh:ce1890cf3af17d569af3bc7673cec0a8f78e6f5d701767593f3d29c551f44848",
+    "zh:e6f1b96eb684f527a47f71923f268c86a36d7894751b31ee9e726d7502a639cd",
+  ]
+}

--- a/terraform/openstack/flavor.tf
+++ b/terraform/openstack/flavor.tf
@@ -1,0 +1,4 @@
+data "openstack_compute_flavor_v2" "medium" {
+  vcpus   = 2
+  min_ram = 4096
+}

--- a/terraform/openstack/image.tf
+++ b/terraform/openstack/image.tf
@@ -1,0 +1,4 @@
+data "openstack_images_image_ids_v2" "image" {
+  name_regex = "^ubuntu-22.*"
+  sort       = "updated_at"
+}

--- a/terraform/openstack/instance.tf
+++ b/terraform/openstack/instance.tf
@@ -1,11 +1,11 @@
 resource "openstack_compute_instance_v2" "minecraft-server" {
   name            = "minecraft-server"
-  image_id        = vars.image_id
-  flavor_id       = vars.flavor_id
+  image_id        = tolist(data.openstack_images_image_ids_v2.image.ids)[0]
+  flavor_id       = data.openstack_compute_flavor_v2.medium.id
   key_pair        = openstack_compute_keypair_v2.minecraft-keypair.name
   security_groups = ["default", openstack_networking_secgroup_v2.minecraft_sg.name]
 
   network {
-    
+    name = "provider"
   }
 }

--- a/terraform/openstack/instance.tf
+++ b/terraform/openstack/instance.tf
@@ -1,5 +1,11 @@
 resource "openstack_compute_instance_v2" "minecraft-server" {
-  name      = "minecraft-server"
-  flavor_id  = vars.flavor_id
-  key_pair  = openstack_compute_keypair_v2.minecraft-keypair.name
+  name            = "minecraft-server"
+  image_id        = vars.image_id
+  flavor_id       = vars.flavor_id
+  key_pair        = openstack_compute_keypair_v2.minecraft-keypair.name
+  security_groups = ["default", openstack_networking_secgroup_v2.minecraft_sg.name]
+
+  network {
+    
+  }
 }

--- a/terraform/openstack/instance.tf
+++ b/terraform/openstack/instance.tf
@@ -1,0 +1,5 @@
+resource "openstack_compute_instance_v2" "minecraft-server" {
+  name      = "minecraft-server"
+  flavor_id  = vars.flavor_id
+  key_pair  = openstack_compute_keypair_v2.minecraft-keypair.name
+}

--- a/terraform/openstack/instance.tf
+++ b/terraform/openstack/instance.tf
@@ -1,3 +1,4 @@
+# Basic instance, but is possible to create it to boot from volume.
 resource "openstack_compute_instance_v2" "minecraft-server" {
   name            = "minecraft-server"
   image_id        = tolist(data.openstack_images_image_ids_v2.image.ids)[0]
@@ -6,6 +7,6 @@ resource "openstack_compute_instance_v2" "minecraft-server" {
   security_groups = ["default", openstack_networking_secgroup_v2.minecraft_sg.name]
 
   network {
-    name = "provider"
+    uuid = data.openstack_networking_network_v2.network.id
   }
 }

--- a/terraform/openstack/keypair.tf
+++ b/terraform/openstack/keypair.tf
@@ -1,0 +1,4 @@
+resource "openstack_compute_keypair_v2" "minecraft-keypair" {
+  name       = "minecraft-keypair"
+  public_key = file("${var.keypair_path}")
+}

--- a/terraform/openstack/main.tf
+++ b/terraform/openstack/main.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = "~> 1.53.0"
+    }
+  }
+}
+
+provider "openstack" {
+}

--- a/terraform/openstack/network.tf
+++ b/terraform/openstack/network.tf
@@ -1,0 +1,3 @@
+resource "openstack_networking" "network" {
+    
+}

--- a/terraform/openstack/network.tf
+++ b/terraform/openstack/network.tf
@@ -1,3 +1,0 @@
-resource "openstack_networking" "network" {
-    
-}

--- a/terraform/openstack/network.tf
+++ b/terraform/openstack/network.tf
@@ -1,0 +1,4 @@
+data "openstack_networking_network_v2" "network" {
+  external = false
+  status = "active"
+}

--- a/terraform/openstack/outputs.tf
+++ b/terraform/openstack/outputs.tf
@@ -1,0 +1,3 @@
+output "vm_public_ip" {
+    value = openstack_compute_instance_v2.minecraft-server.access_ip_v4
+}

--- a/terraform/openstack/security_group.tf
+++ b/terraform/openstack/security_group.tf
@@ -1,34 +1,34 @@
 resource "openstack_networking_secgroup_v2" "minecraft_sg" {
-  name = "minecraft-sg"
- description = "All rules to access minecraft server"
+  name        = "minecraft-sg"
+  description = "All rules to access minecraft server"
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ssh" {
-  direction        = "ingress"
-  ethertype        = "IPv4"
-  protocol         = "tcp"
-  port_range_min   = 22
-  port_range_max   = 22
-  remote_ip_prefix = "0.0.0.0/0"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "server_port" {
-  direction        = "ingress"
-  ethertype        = "IPv4"
-  protocol         = "tcp"
-  port_range_min   = 25565
-  port_range_max   = 25565
-  remote_ip_prefix = "0.0.0.0/0"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 25565
+  port_range_max    = 25565
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
 }
 
 resource "openstack_networking_secgroup_rule_v2" "ping" {
-  direction        = "ingress"
-  ethertype        = "IPv4"
-  protocol         = "icmp"
-  port_range_min   = 0
-  port_range_max   = 0
-  remote_ip_prefix = "0.0.0.0/0"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  port_range_min    = 0
+  port_range_max    = 0
+  remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
 }

--- a/terraform/openstack/security_group.tf
+++ b/terraform/openstack/security_group.tf
@@ -1,0 +1,34 @@
+resource "openstack_networking_secgroup_v2" "minecraft_sg" {
+  name = "minecraft-sg"
+ description = "All rules to access minecraft server"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh" {
+  direction        = "ingress"
+  ethertype        = "IPv4"
+  protocol         = "tcp"
+  port_range_min   = 22
+  port_range_max   = 22
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "server_port" {
+  direction        = "ingress"
+  ethertype        = "IPv4"
+  protocol         = "tcp"
+  port_range_min   = 25565
+  port_range_max   = 25565
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ping" {
+  direction        = "ingress"
+  ethertype        = "IPv4"
+  protocol         = "icmp"
+  port_range_min   = 0
+  port_range_max   = 0
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.minecraft_sg.id
+}

--- a/terraform/openstack/vars.tf
+++ b/terraform/openstack/vars.tf
@@ -3,12 +3,12 @@ variable "keypair_path" {
   default = "~/.ssh/id_rsa.pub"
 }
 
-variable "flavor_id" {
-  type    = string
-  default = openstack_compute_flavor_v2.medium.id
-}
+# variable "flavor_id" {
+#   type    = string
+#   default = openstack_compute_flavor_v2.medium.id
+# }
 
-variable "image_id" {
-  type    = string
-  default = openstack_images_image_ids_v2.image.ids
-}
+# variable "image_id" {
+#   type    = string
+#   default = openstack_images_image_ids_v2.image.ids
+# }

--- a/terraform/openstack/vars.tf
+++ b/terraform/openstack/vars.tf
@@ -2,13 +2,3 @@ variable "keypair_path" {
   type    = string
   default = "~/.ssh/id_rsa.pub"
 }
-
-# variable "flavor_id" {
-#   type    = string
-#   default = openstack_compute_flavor_v2.medium.id
-# }
-
-# variable "image_id" {
-#   type    = string
-#   default = openstack_images_image_ids_v2.image.ids
-# }

--- a/terraform/openstack/vars.tf
+++ b/terraform/openstack/vars.tf
@@ -1,0 +1,9 @@
+variable "keypair_path" {
+  type    = string
+  default = "$HOME/.ssh/id_rsa.pub"
+}
+
+variable "flavor_id" {
+  type    = string
+  default = "general.medium"
+}

--- a/terraform/openstack/vars.tf
+++ b/terraform/openstack/vars.tf
@@ -1,9 +1,14 @@
 variable "keypair_path" {
   type    = string
-  default = "$HOME/.ssh/id_rsa.pub"
+  default = "~/.ssh/id_rsa.pub"
 }
 
 variable "flavor_id" {
   type    = string
-  default = "general.medium"
+  default = openstack_compute_flavor_v2.medium.id
+}
+
+variable "image_id" {
+  type    = string
+  default = openstack_images_image_ids_v2.image.ids
 }


### PR DESCRIPTION
## Done
- O arquivo com as configurações principais do provider é o .env;
- A instância sobe com 2 VCPU e 4GB RAM;
- Adicionei no script de parse, a opção de openstack como argumento;
- Procurei seguir o mesmo padrão dos outros providers;
- Coloquei para que não fosse atachado nenhum floating ip, pois o intuito era didático;


## To do
- Melhorar o regex do datasource da imagem. Usei como base apenas o meu ambiente;
- Refinar a detecção da rede default e adicionar a opção de criar uma nova rede;
- Colocar ip público na criação da instância;
- Adicionar no README a documentação do provider.