### PR TITLE
feat: add Magalu Cloud provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 
 * An Hetzner Cloud account with a valid [API access token](https://docs.hetzner.com/cloud/api/getting-started/generating-api-token/).
 
+### Magalu Cloud
+
+* A Magalu Cloud account with a valid [API Key](https://console.magalu.cloud/credentials).
+
 ## Which resources does Terraform will provision?
 
 ### AWS
@@ -31,6 +35,12 @@
 | Instance Type | OS           | RAM  | vCPUs |
 |---------------|--------------|------|-------|
 | CPX21         | Ubuntu 22.04 | 4GB  |  3    |
+
+### Magalu Cloud
+
+| Instance Type | OS           | RAM  | vCPUs |
+|---------------|--------------|------|-------|
+| BV2-4-10      | Ubuntu 24.04 | 4GB  |  2    |
 
 ## How to
 
@@ -47,7 +57,7 @@ The other variables are self-explainable.
 1. Init terraform:
 
 ```bash
-cd terraform/<aws | hetzner> && terraform init
+cd terraform/<aws | hetzner | magalu | openstack> && terraform init
 ```
 
 2. Create, if not existent, an SSH key:
@@ -56,12 +66,12 @@ cd terraform/<aws | hetzner> && terraform init
 ssh-keygen
 ```
 
-3. Config your credentials on `./env/.env.<aws | hetzner>`
+3. Config your credentials on `./env/.env.<aws | hetzner | magalu | openstack>`
 
 4. Provision your server:
 
 ```bash
-./provision.sh <aws | hetzner>
+./provision.sh <aws | hetzner | magalu | openstack>
 ```
 
 ### Just Configure
@@ -87,7 +97,7 @@ cd ansible && ansible-playbook -i hosts.ini -v playbook.yml
 If you want to destroy your Minecraft Server instances, just run:
 
 ```bash
-./destroy.sh <aws | hetzner>
+./destroy.sh <aws | hetzner | magalu | openstack>
 ```
 
 ## Playing
@@ -120,3 +130,8 @@ TODO
 
 | ~ 7.00€ / month |
 |-----------------|
+
+### Magalu Cloud
+
+| ~ R$ 82,99 / month |
+|--------------------|

--- a/ansible/roles/minecraft-server/handlers/main.yml
+++ b/ansible/roles/minecraft-server/handlers/main.yml
@@ -11,5 +11,5 @@
 
 - name: Reload sshd
   ansible.builtin.systemd:
-    name: sshd
+    name: ssh
     state: reloaded

--- a/env/.env.magalu.sample
+++ b/env/.env.magalu.sample
@@ -1,0 +1,3 @@
+# Get your API key at: https://console.magalu.cloud/credentials
+export MGC_API_KEY=
+export MGC_REGION=br-ne1

--- a/parse_tf_output.py
+++ b/parse_tf_output.py
@@ -12,7 +12,8 @@ provider = sys.argv[1]
 PROVIDER_USER_MAP = {
     'aws': 'ubuntu',
     'openstack': 'ubuntu',
-    'hetzner': 'root'
+    'hetzner': 'root',
+    'magalu': 'ubuntu'
 }
 
 user = PROVIDER_USER_MAP.get(provider)

--- a/provision.sh
+++ b/provision.sh
@@ -1,13 +1,20 @@
 #!/bin/bash
 
+TF_CMD=$(command -v opentofu || command -v terraform)
+
+if [ -z "$TF_CMD" ]; then
+  echo "Error: neither opentofu nor terraform found in PATH"
+  exit 1
+fi
+
 function provision_infra() {
   provider=$1
 
   source env/.env.$provider && \
       cd terraform/$provider && \
-      opentofu init && \
-      opentofu apply -auto-approve && \
-      opentofu output -json | tee ../../output.json && cd -
+      $TF_CMD init && \
+      $TF_CMD apply -auto-approve && \
+      $TF_CMD output -json | tee ../../output.json && cd -
 }
 
 function config_ansible_hosts() {

--- a/terraform/magalu/.terraform.lock.hcl
+++ b/terraform/magalu/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/magalucloud/mgc" {
+  version     = "0.45.1"
+  constraints = "~> 0.45"
+  hashes = [
+    "h1:rBb426cjWq751PBItvfsIZ7csF2HVL80UfGmwGbDtI0=",
+    "zh:07ea7716f759b026c458bb816483dc3c480c8075eb39fee4470eb558c76f72be",
+    "zh:1bae67389d5fd5e46fc1168d5928241bfb127b3ce2b98e0837d30419244163a3",
+    "zh:445738d401b448fa174e42b91166673cbd155d535833ca783d16866e9168a748",
+    "zh:55f684def137dd2144f7df9a32bd4fb0d61001b466e7a6a8802958095f2ce060",
+    "zh:580cbb88830e8243df1cc334c67689b8378b410bf6f1cca148c0acf4afcbdb29",
+    "zh:694281e3a474a6a525d6889d73d2a2880f9c137c5d03e0cab3fab78b31ea8e49",
+    "zh:839cf9b979ae6ff5050d1b4b4f05408abc3224222cc5aa0b432c3f57db43e866",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:c42d3a4979740ea08f54b4238dd5b07ed966cbeebfbdbfdd1102831a14e2a384",
+  ]
+}

--- a/terraform/magalu/instance.tf
+++ b/terraform/magalu/instance.tf
@@ -1,0 +1,8 @@
+resource "mgc_virtual_machine_instances" "minecraft_server" {
+  name                     = "minecraft-server"
+  machine_type             = var.machine_type
+  image                    = var.image
+  ssh_key_name             = mgc_ssh_keys.minecraft_server_key.name
+  allocate_public_ipv4     = true
+  creation_security_groups = [mgc_network_security_groups.minecraft_sg.id]
+}

--- a/terraform/magalu/main.tf
+++ b/terraform/magalu/main.tf
@@ -10,6 +10,7 @@ terraform {
 variable "api_key" {
   type        = string
   description = "Magalu Cloud API Key"
+  sensitive   = true
 }
 
 provider "mgc" {

--- a/terraform/magalu/main.tf
+++ b/terraform/magalu/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_providers {
+    mgc = {
+      source  = "magalucloud/mgc"
+      version = "~> 0.45"
+    }
+  }
+}
+
+variable "api_key" {
+  type        = string
+  description = "Magalu Cloud API Key"
+}
+
+provider "mgc" {
+  api_key = var.api_key
+  region  = var.region
+}

--- a/terraform/magalu/outputs.tf
+++ b/terraform/magalu/outputs.tf
@@ -1,0 +1,3 @@
+output "vm_public_ip" {
+  value = mgc_virtual_machine_instances.minecraft_server.ipv4
+}

--- a/terraform/magalu/security_group.tf
+++ b/terraform/magalu/security_group.tf
@@ -1,0 +1,35 @@
+resource "mgc_network_security_groups" "minecraft_sg" {
+  name        = "minecraft-sg"
+  description = "Security group for Minecraft server"
+}
+
+resource "mgc_network_security_groups_rules" "ssh" {
+  description       = "Allow SSH"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = mgc_network_security_groups.minecraft_sg.id
+}
+
+resource "mgc_network_security_groups_rules" "minecraft_port" {
+  description       = "Allow Minecraft Java Edition"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 25565
+  port_range_max    = 25565
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = mgc_network_security_groups.minecraft_sg.id
+}
+
+resource "mgc_network_security_groups_rules" "icmp" {
+  description       = "Allow ICMP (ping)"
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = mgc_network_security_groups.minecraft_sg.id
+}

--- a/terraform/magalu/security_group.tf
+++ b/terraform/magalu/security_group.tf
@@ -1,35 +1,40 @@
+locals {
+  sg_rules = {
+    ssh = {
+      description    = "Allow SSH"
+      protocol       = "tcp"
+      port_range_min = 22
+      port_range_max = 22
+    }
+    minecraft_port = {
+      description    = "Allow Minecraft Java Edition"
+      protocol       = "tcp"
+      port_range_min = 25565
+      port_range_max = 25565
+    }
+    icmp = {
+      description    = "Allow ICMP (ping)"
+      protocol       = "icmp"
+      port_range_min = null
+      port_range_max = null
+    }
+  }
+}
+
 resource "mgc_network_security_groups" "minecraft_sg" {
   name        = "minecraft-sg"
   description = "Security group for Minecraft server"
 }
 
-resource "mgc_network_security_groups_rules" "ssh" {
-  description       = "Allow SSH"
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 22
-  port_range_max    = 22
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = mgc_network_security_groups.minecraft_sg.id
-}
+resource "mgc_network_security_groups_rules" "this" {
+  for_each = local.sg_rules
 
-resource "mgc_network_security_groups_rules" "minecraft_port" {
-  description       = "Allow Minecraft Java Edition"
+  description       = each.value.description
   direction         = "ingress"
   ethertype         = "IPv4"
-  protocol          = "tcp"
-  port_range_min    = 25565
-  port_range_max    = 25565
-  remote_ip_prefix  = "0.0.0.0/0"
-  security_group_id = mgc_network_security_groups.minecraft_sg.id
-}
-
-resource "mgc_network_security_groups_rules" "icmp" {
-  description       = "Allow ICMP (ping)"
-  direction         = "ingress"
-  ethertype         = "IPv4"
-  protocol          = "icmp"
+  protocol          = each.value.protocol
+  port_range_min    = each.value.port_range_min
+  port_range_max    = each.value.port_range_max
   remote_ip_prefix  = "0.0.0.0/0"
   security_group_id = mgc_network_security_groups.minecraft_sg.id
 }

--- a/terraform/magalu/ssh_key.tf
+++ b/terraform/magalu/ssh_key.tf
@@ -1,0 +1,4 @@
+resource "mgc_ssh_keys" "minecraft_server_key" {
+  name = "minecraft-server-key"
+  key  = file(var.ssh_key_path)
+}

--- a/terraform/magalu/vars.tf
+++ b/terraform/magalu/vars.tf
@@ -1,0 +1,23 @@
+variable "region" {
+  type        = string
+  default     = "br-ne1"
+  description = "Magalu Cloud region"
+}
+
+variable "machine_type" {
+  type        = string
+  default     = "BV2-4-10"
+  description = "Machine type: 2 vCPU, 4 GB RAM, 10 GB disk"
+}
+
+variable "image" {
+  type        = string
+  default     = "cloud-ubuntu-24.04 LTS"
+  description = "OS image name"
+}
+
+variable "ssh_key_path" {
+  type        = string
+  default     = "~/.ssh/id_rsa.pub"
+  description = "Path to the local public SSH key file"
+}


### PR DESCRIPTION
* Implement Terraform module for Magalu Cloud (VM, SG, SSH key)
* Update Python parser to support 'magalu' output and map to 'ubuntu' user
* Refactor provision.sh to auto-detect terraform or opentofu bin
* Fix Ansible handler service name from 'sshd' to 'ssh' for Ubuntu compatibility
* Update README.md with Magalu Cloud instructions and pricing